### PR TITLE
feat: Add lowerShadow() method to ShadowStyle

### DIFF
--- a/Sources/Bones/Foundation/Elevations/Elevation.swift
+++ b/Sources/Bones/Foundation/Elevations/Elevation.swift
@@ -23,15 +23,15 @@ public extension ShadowStyle {
 
     public var id: String {
       switch self {
-        case .none: return "none"
-        case .reallyClose: return "reallyClose"
-        case .close: return "close"
-        case .medium: return "medium"
-        case .far: return "far"
+        case .none: "none"
+        case .reallyClose: "reallyClose"
+        case .close: "close"
+        case .medium: "medium"
+        case .far: "far"
       }
     }
-    
-    public func lowerShadow() -> BonesShadowToken {
+
+    public var lowerShadow: BonesShadowToken {
       switch self {
         case .none: .none
         case .reallyClose: .none

--- a/Sources/Bones/Foundation/Elevations/Elevation.swift
+++ b/Sources/Bones/Foundation/Elevations/Elevation.swift
@@ -30,6 +30,16 @@ public extension ShadowStyle {
         case .far: return "far"
       }
     }
+    
+    public func lowerShadow() -> BonesShadowToken {
+      switch self {
+        case .none: .none
+        case .reallyClose: .none
+        case .close: .reallyClose
+        case .medium: .close
+        case .far: .medium
+      }
+    }
   }
 
   /// Provides a convenient way to access predefined shadow styles.

--- a/Sources/Bones/Preview/Exemple.swift
+++ b/Sources/Bones/Preview/Exemple.swift
@@ -17,8 +17,8 @@ struct SwiftUIViewTest: View {
   }
 
   init() {
-    Bones.update(.color(.primary, with: "#f7bc6f"))
-    Bones.update(.spacing(.medium, with: 64))
+    Bones.update(.color(.primary, withColor: "#f7bc6f"))
+    Bones.update(.spacing(.medium, withPading: 64))
   }
 }
 

--- a/Sources/Bones/Support/Components/Buttons/BoostButton.swift
+++ b/Sources/Bones/Support/Components/Buttons/BoostButton.swift
@@ -6,6 +6,7 @@
 //
 
 import AVKit
+import Pow
 import SwiftUI
 
 struct BonesBoostButton: ButtonStyle {

--- a/Sources/Bones/Support/Components/Buttons/LargeButton.swift
+++ b/Sources/Bones/Support/Components/Buttons/LargeButton.swift
@@ -50,7 +50,7 @@ struct BonesLargeButton: ButtonStyle {
       .cornerRadius(.bones(.small))
       .shadow(
         radius: configuration.isPressed
-          ? .bones(.none)
+          ? .bones(.close.lowerShadow)
           : .bones(.close)
       )
       .conditionalEffect(
@@ -142,7 +142,7 @@ struct BonesLargeButtonOutline: ButtonStyle {
       )
       .shadow(
         radius: configuration.isPressed
-          ? .bones(.none)
+          ? .bones(.close.lowerShadow)
           : .bones(.close)
       )
       .conditionalEffect(

--- a/Sources/Bones/Support/Components/Buttons/NavbarIconButton.swift
+++ b/Sources/Bones/Support/Components/Buttons/NavbarIconButton.swift
@@ -59,7 +59,7 @@ struct BonesNavbarIconButton: ButtonStyle {
           Circle()
             .fill(
               .ultraThinMaterial
-                .shadow(.bones.drop(configuration.isPressed ? .none : .reallyClose))
+                .shadow(.bones.drop(configuration.isPressed ? .reallyClose.lowerShadow : .reallyClose))
             )
             .overlay(content: {
               configuration.isPressed

--- a/Sources/Bones/Support/Components/Buttons/PlayButton.swift
+++ b/Sources/Bones/Support/Components/Buttons/PlayButton.swift
@@ -19,9 +19,12 @@ struct BonesPlayButton: ButtonStyle {
       Circle()
         .fill(
           Color.bones.primary
-            .shadow(.bones.drop(configuration.isPressed
-                ? .reallyClose
-                : .close)
+            .shadow(
+              .bones.drop(
+                configuration.isPressed
+                  ? .close.lowerShadow
+                  : .close
+              )
             )
         )
         .frame(width: 64, height: 64)
@@ -29,9 +32,12 @@ struct BonesPlayButton: ButtonStyle {
       Circle()
         .fill(
           Color.bones.primary
-            .shadow(.bones.drop(configuration.isPressed
-                ? .close
-                : .far)
+            .shadow(
+              .bones.drop(
+                configuration.isPressed
+                  ? .far.lowerShadow
+                  : .far
+              )
             )
         )
         .frame(width: 56, height: 56)

--- a/Sources/Bones/Support/Components/Buttons/RectangleButton.swift
+++ b/Sources/Bones/Support/Components/Buttons/RectangleButton.swift
@@ -24,7 +24,7 @@ public struct BonesRectangleButton: ButtonStyle {
         RoundedRectangle(bonesRadius: .bones(radius), style: .continuous)
           .fill(
             Color(.bones(fillColor))
-              .shadow(.bones.drop(configuration.isPressed ? .none : shadow))
+              .shadow(.bones.drop(configuration.isPressed ? shadow.lowerShadow : shadow))
           )
       }
       .conditionalEffect(

--- a/Sources/Bones/Support/Components/Buttons/SocialTagSelectionButton.swift
+++ b/Sources/Bones/Support/Components/Buttons/SocialTagSelectionButton.swift
@@ -72,7 +72,7 @@ struct BonesSocialTagSelectionButton: ButtonStyle {
       .shadow(
         radius: .bones(
           isEnabled
-            ? configuration.isPressed ? .close : .far
+            ? configuration.isPressed ? .far.lowerShadow : .far
             : .none
         )
       )

--- a/Sources/Bones/Support/Components/Buttons/TrackerRoundButton.swift
+++ b/Sources/Bones/Support/Components/Buttons/TrackerRoundButton.swift
@@ -133,7 +133,7 @@ public struct BonesTrackerRoundButton: ButtonStyle {
             backgroundColor
               .shadow(
                 .bones.drop(
-                  configuration.isPressed ? .none : .far
+                  configuration.isPressed ? .far.lowerShadow : .far
                 )
               )
           )


### PR DESCRIPTION
## **User description**
This commit adds a new method `lowerShadow()` to the `ShadowStyle` extension in the `Elevation.swift` file. The method returns a `BonesShadowToken` based on the current shadow style, allowing for easy access to lower shadow styles.


___

## **Type**
enhancement


___

## **Description**
- Introduced a new method `lowerShadow()` in the `ShadowStyle` extension within `Elevation.swift`.
- This method facilitates the retrieval of a lower shadow style (`BonesShadowToken`) based on the current shadow style, enhancing the flexibility and usability of shadow management in UI components.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Elevation.swift</strong><dd><code>Add `lowerShadow()` Method for Shadow Style Adjustments</code>&nbsp; &nbsp; </dd></summary>
<hr>

Sources/Bones/Foundation/Elevations/Elevation.swift
<li>Added a new method <code>lowerShadow()</code> to the <code>ShadowStyle</code> extension.<br> <li> The <code>lowerShadow()</code> method returns a <code>BonesShadowToken</code> representing a <br>lower shadow style based on the current shadow style.


</details>
    

  </td>
  <td><a href="https://github.com/phoenisis/bones-swiftui/pull/3/files#diff-a2a9a17b81e30063abb59f2ef0bdee1b64673f4c9a49e57920026af8eeed2dc6">+10/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

